### PR TITLE
Fix for push right

### DIFF
--- a/jquery.panelslider.js
+++ b/jquery.panelslider.js
@@ -82,7 +82,7 @@
               left: 'auto',
               right: '-' + panelWidth + 'px'
             });
-            bodyAnimation['margin-right'] = '+=' + panelWidth;
+            bodyAnimation['margin-left'] = '-=' + panelWidth;
             panelAnimation.right = '+=' + panelWidth;
             break;
         }
@@ -171,7 +171,7 @@
             break;
 
           case 'right':
-            bodyAnimation['margin-right'] = '-=' + panelWidth;
+            bodyAnimation['margin-left'] = '+=' + panelWidth;
             panelAnimation.right = '-=' + panelWidth;
             break;
         }


### PR DESCRIPTION
Push right needs to adjust the left margin of the body in a negative fashion rather than the right margin in a positive fashion.
